### PR TITLE
Fix bug in multipart form submission where file Content-Length header not included

### DIFF
--- a/lib/sailthru.js
+++ b/lib/sailthru.js
@@ -12,6 +12,8 @@
 
   rest = require('restler');
 
+  fs = require('fs');
+
   /*
   API client version
   */
@@ -208,12 +210,13 @@
     */
 
     SailthruClient.prototype.apiPostMultiPart = function(action, data, callback, binary_data_params) {
-      var binary_data, json_payload, param, value, _i, _len, _url;
+      var binary_data, json_payload, param, value, _i, _len, _url, stats;
       if (binary_data_params == null) binary_data_params = [];
       binary_data = {};
       for (_i = 0, _len = binary_data_params.length; _i < _len; _i++) {
         param = binary_data_params[_i];
-        binary_data[param] = rest.file(data[param]);
+        stats = fs.statSync(data[param]);
+        binary_data[param] = rest.file(data[param], null, stats.size);
         delete data[param];
       }
       _url = url.parse(this.api_url);


### PR DESCRIPTION
Added an fs.statSync() call to get the file size before creating a restler file.

Without this, you always get a "411 Length Required" response from the import list Job API.

Please include to fix the import API.
