### PR TITLE
Fix multiple-part POST and blast from_email

### DIFF
--- a/src/sailthru.coffee
+++ b/src/sailthru.coffee
@@ -167,7 +167,11 @@ class SailthruClient
             binary_data_params = undefined
         if binary_data_params is undefined
             binary_data_params = []
-        if binary_data_params.length > 0 then @apiPostMultiPart action, data, callback, binary_data_params else @_apiRequest action, data, 'POST', callback
+            
+        if binary_data_params.length > 0
+            @apiPostMultiPart action, data, binary_data_params, callback
+        else
+            @_apiRequest action, data, 'POST', callback
 
     ###
     POST call with Multipart
@@ -330,7 +334,7 @@ class SailthruClient
         data.list = list
         data.schedule_time = scheduleTime
         data.from_name = fromName
-        data.from_emai = fromEmail
+        data.from_email = fromEmail
         data.subject = subject
         data.content_html = contentHtml
         data.content_text = contentText


### PR DESCRIPTION
Fixes two instances where the library fails or doesn't work properly without explanation, due to argument order and a typo.

Also, the docs disagree on parameter order for multi-part posts. But this change at least makes the code work.