### PR TITLE
allow for passing test api endpoint with custom port

### DIFF
--- a/src/sailthru.coffee
+++ b/src/sailthru.coffee
@@ -35,8 +35,8 @@ class SailthruRequest
             binary_data_params = []
         parse_uri = url.parse uri
         options =
-            host: parse_uri.host
-            port: if parse_uri.protocol is 'https:' then 443 else 80
+            host: parse_uri.hostname
+            port: parse_uri.port !== undefined ? parse_uri.port : (parse_uri.protocol === 'https:' ? 443 : 80)
             path: parse_uri.pathname
             method: method
             query: data

--- a/src/sailthru.coffee
+++ b/src/sailthru.coffee
@@ -36,7 +36,7 @@ class SailthruRequest
         parse_uri = url.parse uri
         options =
             host: parse_uri.hostname
-            port: parse_uri.port !== undefined ? parse_uri.port : (parse_uri.protocol === 'https:' ? 443 : 80)
+            port: if parse_uri.port isnt undefined then parse_uri.port else (if parse_uri.protocol is 'https:' then 443 else 80)
             path: parse_uri.pathname
             method: method
             query: data


### PR DESCRIPTION
If you are testing this client locally, you might want to supply a local endpoint like `http://127.0.0.1:8080`.  These changes are required to allow it.