### PR TITLE
Fix: critical multipart job documentation bug

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,9 +80,9 @@ var data = {
     file: './emails.txt'
 };
 var multipart_params = ['file']; // this is required to mark file as a multipart upload item'
-sailthru.apiPost('job', data, function(err, response) {
+sailthru.apiPost('job', data, multipart_params, function(err, response) {
    console.log(response);
-}, multipart_params);
+});
 ```
 
 


### PR DESCRIPTION
I was getting an error message when using job API for importing users using a file (`multipart`).

```
{
  statusCode: 400,
  error: 99,
  errormsg: 'One of the following parameters is required: emails, url, or file' 
}
```

After inspecting Sailthru node module, I figured out that the documentation for `job` API is not correct. Here is the code of `apiPost` method from sailthru node module.

```
SailthruClient.prototype.apiPost = function(action, data, binary_data_params, callback) {
      if (typeof binary_data_params === 'function') {
        callback = binary_data_params;
        binary_data_params = void 0;
      }
      if (binary_data_params === void 0) {
        binary_data_params = [];
      }
      if (binary_data_params.length > 0) {
        return this.apiPostMultiPart(action, data, binary_data_params, callback);
      } else {
        return this._apiRequest(action, data, 'POST', callback);
      }
    };
```

If third parameter `binary_data_params` is a function in a `multipart` request as stated in the docs, it would never call `apiPostMultiPart`. So third parameter must be `multipart` and the last must be a callback function.

Just fixed that..