### PR TITLE
FIX multipart upload issue by updating dependency

### DIFF
--- a/lib/sailthru.js
+++ b/lib/sailthru.js
@@ -10,7 +10,7 @@
 
   querystring = require('querystring');
 
-  rest = require('restler');
+  rest = require('restler-base');
 
   fs = require('fs');
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,61 @@
+{
+  "name": "sailthru-client",
+  "version": "3.0.2",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "iconv-lite": {
+      "version": "0.4.23",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.23.tgz",
+      "integrity": "sha512-neyTUVFtahjf0mB3dZT77u+8O0QB89jFdnBkd5P1JgYPbPaia3gXXOVL2fq8VyU2gMMD7SaN7QukTB/pmXYvDA==",
+      "requires": {
+        "safer-buffer": "2.1.2"
+      }
+    },
+    "qs": {
+      "version": "6.5.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
+      "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA=="
+    },
+    "restler-base": {
+      "version": "3.4.6",
+      "resolved": "https://registry.npmjs.org/restler-base/-/restler-base-3.4.6.tgz",
+      "integrity": "sha512-WWiivZStHYyUxyqkQat5pyRYb/S8wpWn3Y8bpcVRMW9Cs0R/Qv/f/WrjWNJM430ewZH6nCORGrNHqzXSAms60Q==",
+      "requires": {
+        "iconv-lite": "0.4.23",
+        "qs": "6.5.2",
+        "xml2js": "0.4.19",
+        "yaml": "0.3.0"
+      }
+    },
+    "safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
+    },
+    "sax": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
+      "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw=="
+    },
+    "xml2js": {
+      "version": "0.4.19",
+      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.19.tgz",
+      "integrity": "sha512-esZnJZJOiJR9wWKMyuvSE1y6Dq5LCuJanqhxslH2bxM6duahNZ+HMpCLhBQGZkbX6xRf8x1Y2eJlgt2q3qo49Q==",
+      "requires": {
+        "sax": "1.2.4",
+        "xmlbuilder": "9.0.7"
+      }
+    },
+    "xmlbuilder": {
+      "version": "9.0.7",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-9.0.7.tgz",
+      "integrity": "sha1-Ey7mPS7FVlxVfiD0wi35rKaGsQ0="
+    },
+    "yaml": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-0.3.0.tgz",
+      "integrity": "sha1-wxphbQes28IBLXOmulsbC90YWn8="
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   },
   "main": "./lib/sailthru.js",
   "dependencies": {
-    "restler": "^3.4.0"
+    "restler-base": "^3.4.6"
   },
   "devDependencies": {
     "grunt": "^1.0.1",


### PR DESCRIPTION
'fs' module changes between Node 7 and Node 8 have caused import jobs to stop working. This fix updates the 'restler' dependency (no longer maintained) to 'restler-base' (an actively maintained fork).