### PR TITLE
Fix the JavaScript heap out of memory error

### DIFF
--- a/lib/sailthru.js
+++ b/lib/sailthru.js
@@ -297,10 +297,12 @@
       _url = url.parse(this.api_url);
 
       json_payload = this._json_payload(data);
+      json_payload_to_log = json_payload;
 
       for (param in binary_data) {
         value = binary_data[param];
         json_payload[param] = value;
+        json_payload_to_log[param] = '[TRUNCATED]';
       }
 
       options = {
@@ -316,7 +318,8 @@
 
       this.log2(_url.href + action);
       this.log2('MultiPart Request');
-      this.log2('JSON Payload: ' + JSON.stringify(json_payload));
+      this.log2('JSON Payload: ' + JSON.stringify(json_payload_to_log));
+
       return rest.post(
         _url.href + action,
         json_payload,

--- a/lib/sailthru.js
+++ b/lib/sailthru.js
@@ -24,7 +24,7 @@
    */
 
 
-  exports.VERSION = '5.0.0';
+  exports.VERSION = '5.0.1';
 
 
   USER_AGENT = 'Sailthru API Node/JavaScript Client ' + exports.VERSION;

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sailthru-client",
   "description": "Node.js client for Sailthru API",
-  "version": "5.0.0",
+  "version": "5.0.1",
   "author": {
     "name": "George Liao",
     "email": "gliao@sailthru.com",

--- a/test/test_sailthru.js
+++ b/test/test_sailthru.js
@@ -450,12 +450,19 @@
   };
 
   exports.processJobWithFile = function(test) {
+    var SailthruClientWithMockLog2Function = require('../lib/sailthru').createSailthruClient('abcd12345', '1324qwerty');
+    SailthruClientWithMockLog2Function.log2 = function(string) {
+      if (/json payload/i.test(string)) {
+        test.ok(/TRUNCATED/.test(string));
+      }
+    }
+
     nock(/.*sailthru.com.*/)
       .post(/.*/, function(q) {
         return q.match(/new_users.csv/);
       }).reply(200, 'success');
 
-    test.expect(1);
+    test.expect(2);
 
     var callback = function(err, res) {
       test.equal(err, undefined);
@@ -465,7 +472,7 @@
       list: 'abc',
       file: 'tmp/new_users.csv'
     };
-    SailthruClient.processJob('import', options, 'report@example.com', 'http://example.com/post.php', ['file'], callback);
+    SailthruClientWithMockLog2Function.processJob('import', options, 'report@example.com', 'http://example.com/post.php', ['file'], callback);
   };
 
   exports.getLastRateLimitInfoSingleCase = function(test) {


### PR DESCRIPTION
[UI-615](https://sailthru.atlassian.net/browse/UI-615)

This PR fixes the "JavaScript heap out of memory" error one of our customers has run into recently.

Let's call the `processJob` method or any other method that itself calls [`apiPostMultiPart`](https://github.com/sailthru/sailthru-node-client/blob/v5.0.0/lib/sailthru.js#L281):

```js
const sailthru = require('sailthru-client').createSailthruClient('apiKey', 'apiSecret')
sailthru.enableLogging()

const data = {
  job: 'import',
  list: 'test-list',
  file: './test.txt'
}
sailthru.apiPost('job', data, ['file'], (error, response) => {
  console.log(error, response)
})
```

Here's the log message we can expect to see as a result of running the above code:
```
9 Nov 11:36:59 - sailthru-client - JSON Payload: {"api_key":"apiKey","format":"json","json":"{\"job\":\"import\",\"list\":\"test-list\"}","sig":"1a930db51af49a27d9cc1986eba4af6d","file":{"buffer":{"type":"Buffer","data":[123,10,32,32,34,97,34,58,32,49,44,10,32,32,34,98,34,58,32,50,44,10,32,32,34,99,34,58,32,51,10,125,10]},"filename":"test.txt","content_type":"application/octet-stream"}}
```

In case of a much bigger file (~ 200MB) Node.js gets us the following error depending on how much memory has been allocated to it:
```
FATAL ERROR: invalid table size Allocation failed - JavaScript heap out of memory
```

This PR simply prevents the binary content of the file (or files) the user wants to send to the Sailthru API from appearing in the log output by replacing it with `"[TRUNCATED]"`. Here's an example:
```
10 Nov 13:30:53 - sailthru-client - JSON Payload: {"api_key":"apiKey","format":"json","json":"{\"job\":\"import\",\"list\":\"test-list\"}","sig":"1a930db51af49a27d9cc1986eba4af6d","file":"[TRUNCATED]"}
```


[UI-615]: https://sailthru.atlassian.net/browse/UI-615?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ