### PR TITLE
Fix for logging interfering with multipart uploads

### DIFF
--- a/lib/sailthru.js
+++ b/lib/sailthru.js
@@ -297,7 +297,7 @@
       _url = url.parse(this.api_url);
 
       json_payload = this._json_payload(data);
-      json_payload_to_log = json_payload;
+      json_payload_to_log = this._json_payload(data);
 
       for (param in binary_data) {
         value = binary_data[param];

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sailthru-client",
   "description": "Node.js client for Sailthru API",
-  "version": "5.0.1",
+  "version": "5.0.2",
   "author": {
     "name": "George Liao",
     "email": "gliao@sailthru.com",


### PR DESCRIPTION
A proposed solution for [Issue #49](https://github.com/sailthru/sailthru-node-client/issues/49), where an effort to log a multipart payload by [creating a duplicate object](https://github.com/sailthru/sailthru-node-client/blob/72c640e09f4447ed835b1f857a98d6036f9533a1/lib/sailthru.js#L300) inadvertently modifies the request payload itself. The result was that multipart requests to the Job API were sending a string meant for logging rather than a file, and this was somehow triggering the signature hash error message.

This is a one-line fix which should preserve the integrity of the request payload.