### PR TITLE
Fix missing comma in variable declaration list

### DIFF
--- a/lib/sailthru.js
+++ b/lib/sailthru.js
@@ -1,5 +1,5 @@
 (function() {
-  var SailthruClient, SailthruRequest, SailthruUtil, USER_AGENT, fs, http, https, log, querystring, ref, rest, url, multipart
+  var SailthruClient, SailthruRequest, SailthruUtil, USER_AGENT, fs, http, https, log, querystring, ref, rest, url, multipart,
     slice = [].slice;
 
   http = require('http');


### PR DESCRIPTION
This package doesn't work when building with Bun. This fixes it. Create a file `main.js` in the top level of this repo and put the following snippet in it then run the shell commands and it will work with this branch. If you do the same on master it will fail.

The error before this fix:

```
6686 | // lib/sailthru.js
6687 | var require_sailthru = __commonJS((exports) => {
6688 |   (function() {
6689 |     slice = [].slice;
                  ^
ReferenceError: Can't find variable: slice
```

I don't know much about JS so maybe there is a better way to do this?

```javascript
import { createSailthruClient } from './lib/sailthru';
const sailthruClient = createSailthruClient('a','b');
sailthruClient.getUserByKey('???','email', (e,r) => {
    console.log(e,r)
});
```

```shell
bun build --compile main.js --outfile buntest
./buntest
```