### PR TITLE
Get tests running again, replace url.parse to avoid depreciation notice

### DIFF
--- a/lib/sailthru.js
+++ b/lib/sailthru.js
@@ -1,12 +1,10 @@
 (function() {
-  var SailthruClient, SailthruRequest, SailthruUtil, USER_AGENT, fs, http, https, log, querystring, ref, rest, url, multipart
+  var SailthruClient, SailthruRequest, SailthruUtil, USER_AGENT, fs, http, https, log, querystring, ref, rest, url, multipart,
     slice = [].slice;
 
   http = require('http');
 
   https = require('https');
-
-  url = require('url');
 
   querystring = require('querystring');
 
@@ -61,7 +59,7 @@
       if (binary_data_params === undefined) {
         binary_data_params = [];
       }
-      parse_uri = url.parse(uri);
+      parse_uri = URL.parse(uri) || new URL();
       options = {
         host: parse_uri.hostname,
         port: parse_uri.port ? parse_uri.port : (parse_uri.protocol === 'http:' ? 80 : 443),
@@ -178,7 +176,7 @@
       if (this.api_url === false) {
         this.api_url = 'https://api.sailthru.com';
       }
-      var _url = url.parse(this.api_url);
+      var _url = url.parse(this.api_url) || new URL();
       if (_url.protocol && _url.protocol !== 'http:' && _url.protocol != 'https:') {
           throw Error('Must specify protocol of http:// or https://');
       }
@@ -229,7 +227,7 @@
 
     SailthruClient.prototype._apiRequest = function(action, data, method, callback) {
       var _url, json_payload;
-      _url = url.parse(this.api_url);
+      _url = URL.parse(this.api_url) || new URL();
       json_payload = this._json_payload(data);
       return this.request._api_request(_url.href + action, json_payload, method, null, callback, this.agent);
     };
@@ -294,7 +292,7 @@
         binary_data[param] = multipart.file(data[param]);
         delete data[param];
       }
-      _url = url.parse(this.api_url);
+      _url = URL.parse(this.api_url) || new URL();
 
       json_payload = this._json_payload(data);
       json_payload_to_log = this._json_payload(data);

--- a/lib/sailthru_util.js
+++ b/lib/sailthru_util.js
@@ -4,6 +4,7 @@
   crypto = require('crypto');
 
   exports.SailthruUtil = SailthruUtil = (function() {
+    function SailthruUtil() {}
 
     SailthruUtil.getSignatureHash = function(params, secret) {
       return SailthruUtil.md5(SailthruUtil.getSignatureString(params, secret));

--- a/package.json
+++ b/package.json
@@ -7,6 +7,9 @@
     "email": "gliao@sailthru.com",
     "url": "http://www.sailthru.com"
   },
+  "scripts": {
+    "test": "grunt"
+  },
   "repository": {
     "type": "git",
     "url": "http://github.com/sailthru/sailthru-node-client.git"


### PR DESCRIPTION
 - Closes https://github.com/sailthru/sailthru-node-client/issues/56
 - Closes https://github.com/sailthru/sailthru-node-client/issues/55

Also adds an npm script to easily run the tests for easier discoverability for new contributors: `npm run test`.