### PR TITLE
Fix missing comma in var declaration that breaks ESM bundlers

### DIFF
--- a/lib/sailthru.js
+++ b/lib/sailthru.js
@@ -1,5 +1,5 @@
 (function() {
-  var SailthruClient, SailthruRequest, SailthruUtil, USER_AGENT, fs, http, https, log, querystring, ref, rest, url, multipart
+  var SailthruClient, SailthruRequest, SailthruUtil, USER_AGENT, fs, http, https, log, querystring, ref, rest, url, multipart,
     slice = [].slice;
 
   http = require('http');


### PR DESCRIPTION
Closes this issue:  https://github.com/sailthru/sailthru-node-client/issues/66

Companion to the earlier `sailthru_util.js` refactor (per its `// refactored to resolve scoping issue` header) — applies the same cleanup to the last CoffeeScript-compiled file in `lib/`.

 ## Issue

  `lib/sailthru.js` is missing a comma in the top-of-IIFE `var` declaration:

  ```js
  (function() {
    var SailthruClient, SailthruRequest, SailthruUtil, USER_AGENT, fs, http,
        https, log, querystring, ref, rest, url, multipart    ← no comma
      slice = [].slice;                                       ← becomes a separate statement
  ```

  Without the comma, ASI ends the `var` list at `multipart` and `slice = [].slice;` becomes a bare assignment to an undeclared identifier. Under CommonJS sloppy mode that silently creates an implicit
  global; under ESM strict mode it throws `ReferenceError: slice is not defined`.

  `slice` is referenced later in the file (CoffeeScript-style splat handling), so the intent was always to declare it locally — this is a pure bug, not a behavior change.

  ## Repro
  
  ```js
  // esbuild bundle.mjs --bundle --format=esm --platform=node
  import sailthru from 'sailthru-client';
  console.log(sailthru);
  ```
  
  ```
  ReferenceError: slice is not defined
      at <module evaluation> (.../node_modules/sailthru-client/lib/sailthru.js:N:N)
  ```

  Same failure under Rollup / Webpack ESM output. Tests presumably don't catch it because they load the module via CJS `require()`, which is sloppy mode.

  ## Fix
  
  Single-character change — add the missing comma so `slice` joins the `var` declaration list it was meant to be part of.

  ## Workaround for downstream users until this lands
  
  Mark `sailthru-client` as `external` in your bundler config so the package stays loaded via runtime `require()`:

  ```yaml
  # esbuild example
  external:
    - sailthru-client
  ```
